### PR TITLE
Adds default CA Certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ metrics-server-exporter provides cpu and memory metrics for nodes and pods, dire
   * K8S_FILEPATH_TOKEN
     * Path of ServiceAccount token file (default /var/run/secrets/kubernetes.io/serviceaccount/token)
 
+  * K8S_CA_CERT_PATH
+    * Path of Kubernetes CA certificate (default /var/run/secrets/kubernetes.io/serviceaccount/ca.crt)
+
   * NAMES_BLACKLIST
     * A list of names from pods, containers or namespaces to exclude from metrics.
+
+### Options
+
+  * --insecure-tls
+    * Disables TLS verification of the Kubernetes API Server.  (Not recommended in production)
 
 ### How to build
 
@@ -51,9 +59,9 @@ metrics-server-exporter provides cpu and memory metrics for nodes and pods, dire
 
 ### How to run
 
-You will need `K8S_TOKEN` and `K8S_ENDPOINT` to access the api-server
+You will need `K8S_TOKEN` and `K8S_ENDPOINT` to access the api-server.  Use "--insecure-tls" or mount the CA certificate into the container.  Kubernetes will provide the CA certificate in a Kubernetes installation.
 
-    $ docker run -p 8000:8000 -e "K8S_ENDPOINT=${K8S_ENDPOINT}" -e "K8S_TOKEN=${K8S_TOKEN}" vivareal/metrics-server-exporter
+    $ docker run -p 8000:8000 -e "K8S_ENDPOINT=${K8S_ENDPOINT}" -e "K8S_TOKEN=${K8S_TOKEN}" vivareal/metrics-server-exporter --insecure-tls
 
 ### How to deploy
 


### PR DESCRIPTION
With "verify=False" set, urllib3 would log every call as:
``` 
/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
```
That's pretty verbose.

Kubernetes normally puts the ca.crt file in with the service token, so we can use that to verify TLS requests and stop the logging.

Added a `K8S_CA_CERT_PATH` environment variable, which defaults to the K8s ca.crt file.  This "just works" on my install.

Also added a "--insecure-tls" option to restore the former behavior for local testing or anywhere that the CA isn't available.

I updated the README with this behavior.

Minor: 
Changed `total` retries to 3 to match `connect`, as TLS negotiation failures don't count as `connect` errors, and the default timeout was reaching minutes.
Sorted imports and added `getopt` for the `--insecure-tls` option. 