### PR TITLE
fix(helm/templates) documentation and helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Enable metrics-server addon
 
 Deploy the files in minikube
 
-	$ kubectl apply -R -f deploy/
+	$ kubectl apply -R -f deploy/ -n kube-system
 
 Then, test the connectivity
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/name: {{ include "metrics-server-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "metrics-server-exporter.fullname" . }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The `kubectl apply` described in documentation does not work. The ClusterRoleBinding references a Service Account in `kube-system`. If you don't add the namespace parameter the objects will be created in the `default` namespace. Therefore the role binding will not find the service account.
If you create all of the objects in the `kube-system` the apply will work.

In helm templates the deploy is missing the `serviceAccountName` therefore the `default` ServiceAccount will be used that does not have the permissions for the metrics server.

This fixes #33 . I can fix the namespace referencing in a more Helm way (see  https://helm.sh/docs/chart_template_guide/builtin_objects/ `Release.Namespace`  ), if you want to except the PR. You will have to install the chart with the `-n` parameter. The current approach could have issues with Helm3 (helm3 relies on namespace namespacing)