### PR TITLE
Fix helm namespace reference in templates and add annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Enable metrics-server addon
 
 Deploy the files in minikube
 
-	$ kubectl apply -R -f deploy/
+	$ kubectl apply -R -f deploy/ -n kube-system
 
 Then, test the connectivity
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.6"
 description: A Helm chart for metrics-server-exporter
 name: metrics-server-exporter
-version: 1.0.0
+version: 0.1.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.6"
 description: A Helm chart for metrics-server-exporter
 name: metrics-server-exporter
-version: 0.1.0
+version: 1.0.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -43,14 +43,3 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
-
-{{/*
-Set namespace, use "kube-system" as default.
-*/}}
-{{- define "metrics-server-exporter.namespace" -}}
-  {{- if .Values.namespaceOverride -}}
-    {{- .Values.namespaceOverride -}}
-  {{- else -}}
-    kube-system
-  {{- end -}}
-{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/name: {{ include "metrics-server-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "metrics-server-exporter.fullname" . }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "metrics-server-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "metrics-server-exporter.fullname" . }}
-  namespace: {{ include "metrics-server-exporter.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "metrics-server-exporter.labels" . | indent 4 }}
 spec:

--- a/helm/templates/permissions.yaml
+++ b/helm/templates/permissions.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "metrics-server-exporter.fullname" . }}
-  namespace: {{ include "metrics-server-exporter.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "metrics-server-exporter.labels" . | indent 4 }}
 ---
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "metrics-server-exporter.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ include "metrics-server-exporter.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   name: {{ include "metrics-server-exporter.fullname" . }}
 roleRef:
   kind: ClusterRole

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "metrics-server-exporter.labels" . | indent 4 }}
+{{- if .Values.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "metrics-server-exporter.fullname" . }}
-  namespace: {{ include "metrics-server-exporter.namespace" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "metrics-server-exporter.labels" . | indent 4 }}
 spec:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,6 +24,16 @@ service:
 #   k8s_filepath_token: ""
 #   k8s_ca_cert_path: ""
 
+podAnnotations:
+  # When installing Prometheus from official Helm charts, it has a job rule that will
+  # discover the pods with the following annotations.
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8000"
+
+serviceAnnotations: {}
+  # Alternatively official Prometheus chart can probe services.
+  # prometheus.io/probe: "true"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This is some  work on #34 . With this changes I can use the project in our/mine platform.

I changed how metadata namespace is handled. HELM saves some data in the cluster in the namespace provided by `-n` flag or `--namespace`. 
Before this PR if you run `helm install ms-exporter-testing  helm` the helm state will be install into `default` namespace and the objects into `kube-system`.
If you run `helm install --namespace prometheus ms-exporter-testing  helm` the objects will be installed in `kube-system` and the state into `prometheus`. You have to read the implementation to deploy to a namespace you want to.
With the change the state and the objects are deployed in the same namespace you provide with the `-n` flag.

I have added annotations that can be used with the official prometheus helm chart. https://github.com/helm/charts/blob/master/stable/prometheus/values.yaml#L1470
With the annotations the Prometheus will pick up a pod/service without defining an explicit job.