### PR TITLE
feat(docker) Add EXPOSE 8000 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6-alpine
 
+EXPOSE 8000
+
 WORKDIR /app
 
 COPY requirements.txt /app


### PR DESCRIPTION
Required when using [gliderlabs consul registrator](https://gliderlabs.github.io/registrator/latest/user/run/#registrator-options) with --internal option