### PR TITLE
feat(helm) Add env variable in helm values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6-alpine
 
+EXPOSE 8000
+
 WORKDIR /app
 
 COPY requirements.txt /app

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -28,8 +28,10 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.custom }}
+          {{- if or (.Values.custom) (.Values.env) }}
           env:
+          {{- end }}
+          {{- if .Values.custom }}
           {{- if .Values.custom.k8s_endpoint }}
           - name: K8S_ENDPOINT
             value: {{ .Values.custom.k8s_endpoint }}
@@ -49,6 +51,11 @@ spec:
           {{- if .Values.custom.k8s_ca_cert_path }}
           - name: K8S_CA_CERT_PATH
             value: "{{ .Values.custom.k8s_ca_cert_path }}"
+          {{- end }}
+          {{- end }}
+          {{- if .Values.env }}
+          {{- with .Values.env }}
+              {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,3 +51,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+env: {}
+  # Add ability to include more opinionated environment variables
+  # - name: POD_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.podIP
+  # - name: SERVICE_8000_NAME
+  #   value: metrics-server-exporter


### PR DESCRIPTION
  Add ability to include more opinionated environment variables, like the ones required by gliderlabs consul registrator

```yaml
  - name: POD_IP
    valueFrom:
      fieldRef:
        fieldPath: status.podIP
  - name: SERVICE_8000_NAME
    value: metrics-server-exporter
```