### PR TITLE
feat(deploy) add kustomization.yaml

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- 00-permissions-metrics-server-exporter.yaml
+- 10-deployment-metrics-server-exporter.yaml
+- 20-service-metrics-server-exporter.yaml


### PR DESCRIPTION
With the kustomization file this can now be installed with remote
builds, like:

    kubectl apply -n kube-system -k github.com/grupozap/metrics-server-exporter/deploy?ref=v0.0.8

or

    kustomize build github.com/grupozap/metrics-server-exporter/deploy?ref=v0.0.8

or extended via another kustomization.yaml:

    apiVersion: kustomize.config.k8s.io/v1beta1
    kind: Kustomization
    namespace: kube-system
    resources:
    - github.com/grupozap/metrics-server-exporter/deploy?ref=v0.0.8

